### PR TITLE
[dsch] adding the type-hidden properties error to Ok and value to Err…

### DIFF
--- a/examples/methods.ts
+++ b/examples/methods.ts
@@ -119,8 +119,8 @@ import { Result, ok, err } from 'okerr-ts/base';
 }
 
 {
-  const okResult: Result<number, 'NOT_FOUND'> = ok(42);
-  const errResult: Result<string, 'ERR_NOT_FOUND'> = err('ERR_NOT_FOUND');
+  const okResult = ok(42) as Result<number, 'NOT_FOUND'>;
+  const errResult = err('ERR_NOT_FOUND') as Result<string, 'ERR_NOT_FOUND'>;
 
   const value = okResult.unpack(); // 42
   const error = errResult.unpack(); // 'ERR_NOT_FOUND'

--- a/package.json
+++ b/package.json
@@ -30,18 +30,19 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@type-challenges/utils": "^0.1.1",
-    "@types/node": "^20.10.5",
     "@eslint/js": "^9.7.0",
+    "@type-challenges/utils": "^0.1.1",
     "@types/eslint": "^9.6.0",
+    "@types/node": "^20.10.5",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
-    "typescript-eslint": "^7.17.0",
     "jest": "^29.7.0",
+    "terser": "^5.33.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "tsup": "^8.3.0",
-    "typescript": "^5.6.2"
+    "typescript": "^5.6.2",
+    "typescript-eslint": "^7.17.0"
   },
   "exports": {
     ".": {

--- a/src/Err.ts
+++ b/src/Err.ts
@@ -14,7 +14,9 @@ export class ErrImpl<E> implements Err<E> {
   }
 
   get value(): never {
-    throw new TypeError('Result is not an Ok', { cause: this });
+    throw new TypeError('Cannot access `value` on an Err instance.', {
+      cause: this,
+    });
   }
 
   map(): Result<never, E> {

--- a/src/Err.ts
+++ b/src/Err.ts
@@ -13,6 +13,10 @@ export class ErrImpl<E> implements Err<E> {
     return true;
   }
 
+  get value(): never {
+    throw new TypeError('Result is not an Ok', { cause: this });
+  }
+
   map(): Result<never, E> {
     return this;
   }

--- a/src/Ok.ts
+++ b/src/Ok.ts
@@ -14,6 +14,10 @@ export class OkImpl<T> implements Ok<T> {
     return false;
   }
 
+  get error(): never {
+    throw new TypeError('Result is not an Err', { cause: this });
+  }
+
   map<S>(fn: (value: T) => S): Result<S, never> {
     return new OkImpl(fn(this.value));
   }

--- a/src/Ok.ts
+++ b/src/Ok.ts
@@ -15,7 +15,9 @@ export class OkImpl<T> implements Ok<T> {
   }
 
   get error(): never {
-    throw new TypeError('Result is not an Err', { cause: this });
+    throw new TypeError('Cannot access `error` on an Ok instance.', {
+      cause: this,
+    });
   }
 
   map<S>(fn: (value: T) => S): Result<S, never> {

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -128,7 +128,9 @@ describe('Result', () => {
 
     it('throws a TypeError for an Err result', () => {
       expect(() => (err('foo') as any).value).toThrowError(
-        new TypeError('Result is not an Ok', { cause: err('foo') }),
+        new TypeError('Cannot access `value` on an Err instance.', {
+          cause: err('foo'),
+        }),
       );
     });
   });
@@ -140,7 +142,9 @@ describe('Result', () => {
 
     it('throws a TypeError for an Ok result', () => {
       expect(() => (ok('foo') as any).error).toThrowError(
-        new TypeError('Result is not an Err', { cause: ok('foo') }),
+        new TypeError('Cannot access `error` on an Ok instance.', {
+          cause: ok('foo'),
+        }),
       );
     });
   });

--- a/src/result.test.ts
+++ b/src/result.test.ts
@@ -121,6 +121,30 @@ describe('Result', () => {
     });
   });
 
+  describe('Ok.value', () => {
+    it('returns the value for an Ok result', () => {
+      expect(ok('foo').value).toBe('foo');
+    });
+
+    it('throws a TypeError for an Err result', () => {
+      expect(() => (err('foo') as any).value).toThrowError(
+        new TypeError('Result is not an Ok', { cause: err('foo') }),
+      );
+    });
+  });
+
+  describe('Err.error', () => {
+    it('returns the error for an Err result', () => {
+      expect(err('foo').error).toBe('foo');
+    });
+
+    it('throws a TypeError for an Ok result', () => {
+      expect(() => (ok('foo') as any).error).toThrowError(
+        new TypeError('Result is not an Err', { cause: ok('foo') }),
+      );
+    });
+  });
+
   describe('isErr', () => {
     it('should return true for an Err result', () => {
       expect(Guards.isErr(err('foo'))).toBe(true);

--- a/tsup.config.js
+++ b/tsup.config.js
@@ -14,7 +14,7 @@ const entries = [
 ];
 
 export default defineConfig(
-  entries.map(([entry, globalName]) => ({
+  entries.map(([entry, globalName, options]) => ({
     entry,
     globalName,
     format: ['iife'],
@@ -24,9 +24,10 @@ export default defineConfig(
       };
     },
     dts: true,
-    minify: false,
+    minify: 'terser',
     splitting: false,
     sourcemap: true,
     outDir: 'dist',
+    ...options,
   })),
 );


### PR DESCRIPTION
… of type never

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new getter methods in `ErrImpl` and `OkImpl` classes to handle error states more explicitly.
	- Added a new dependency, `terser`, for improved minification.

- **Bug Fixes**
	- Enhanced error handling for accessing `value` and `error` properties in `Ok` and `Err` results.

- **Tests**
	- Added new test suites to validate the behavior of `value` and `error` properties for both `Ok` and `Err` results.

- **Chores**
	- Reordered dependencies in `package.json` for better organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->